### PR TITLE
[FIX] addons_paths relative dir

### DIFF
--- a/anybox/recipe/odoo/base.py
+++ b/anybox/recipe/odoo/base.py
@@ -1633,7 +1633,7 @@ class BaseRecipe(object):
             os.path.relpath(
                 addons_path,
                 os.path.join(
-                    self.odoo_dir,
+                    self.bin_dir,
                     'openerp' if 'openerp' in addons_path else 'odoo'
                 ))
             if self._relative_paths


### PR DESCRIPTION
Using bin_dir as relative path for addons paths because _addons_path_ in *openerp.cfg* was one level up.